### PR TITLE
Improve search accessibility and image alt text

### DIFF
--- a/ai-sme/index.html
+++ b/ai-sme/index.html
@@ -143,22 +143,22 @@
                 <div id="library" class="tab-content hidden">
                      <div class="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
                         <div class="card text-center">
-                            <img src="https://placehold.co/400x225/E5E7EB/374151?text=Video" alt="Video thumbnail" class="rounded-md mb-4 w-full">
+                            <img src="https://placehold.co/400x225/E5E7EB/374151?text=Video" alt="Intro to Gemini video overview thumbnail" class="rounded-md mb-4 w-full">
                             <h3 class="text-lg font-semibold text-brand-dark">Intro to Gemini</h3>
                             <a href="https://drive.google.com/file/d/10H_fL0bKVsB-cObFUD5ObETnWJdEMMNY/preview" class="btn btn-secondary w-full mt-4">Watch Now</a>
                         </div>
                          <div class="card text-center">
-                            <img src="https://placehold.co/400x225/E5E7EB/374151?text=Video" alt="Video thumbnail" class="rounded-md mb-4 w-full">
+                            <img src="https://placehold.co/400x225/E5E7EB/374151?text=Video" alt="Gemini Masterclass session thumbnail" class="rounded-md mb-4 w-full">
                             <h3 class="text-lg font-semibold text-brand-dark">Gemini Masterclass</h3>
                             <a href="https://drive.google.com/file/d/1iUCn1lbI4-evB_GvkVWK9QU2Wz_A16IM/preview" class="btn btn-secondary w-full mt-4">Watch Now</a>
                         </div>
                          <div class="card text-center">
-                            <img src="https://placehold.co/400x225/E5E7EB/374151?text=Video" alt="Video thumbnail" class="rounded-md mb-4 w-full">
+                            <img src="https://placehold.co/400x225/E5E7EB/374151?text=Video" alt="Advanced Prompting training thumbnail" class="rounded-md mb-4 w-full">
                             <h3 class="text-lg font-semibold text-brand-dark">Advanced Prompting</h3>
                             <a href="https://drive.google.com/file/d/1mfJbDJcXYyEQuZHm4CYMVuZrhKbGsbEo/preview" class="btn btn-secondary w-full mt-4">Watch Now</a>
                         </div>
                          <div class="card text-center">
-                            <img src="https://placehold.co/400x225/E5E7EB/374151?text=Video" alt="Video thumbnail" class="rounded-md mb-4 w-full">
+                            <img src="https://placehold.co/400x225/E5E7EB/374151?text=Video" alt="AI for Recruiters learning session thumbnail" class="rounded-md mb-4 w-full">
                             <h3 class="text-lg font-semibold text-brand-dark">AI for Recruiters</h3>
                             <a href="https://drive.google.com/file/d/10H_fL0bKVsB-cObFUD5ObETnWJdEMMNY/preview" class="btn btn-secondary w-full mt-4">Watch Now</a>
                         </div>

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
         <!-- Global Search Bar -->
         <div class="search-container mb-12">
             <div class="relative">
+                <label for="global-search" class="sr-only">Search the Randstad GBS Learning Hub</label>
                 <svg class="search-icon w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                         d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>

--- a/shared/styles/utilities.css
+++ b/shared/styles/utilities.css
@@ -35,6 +35,17 @@
 .flex { display: flex; }
 .grid { display: grid; }
 .hidden { display: none !important; }
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
 .relative { position: relative; }
 .absolute { position: absolute; }
 .fixed { position: fixed; }


### PR DESCRIPTION
## Summary
- add an accessible label to the global search input on the home page
- introduce an `sr-only` utility class so the new label remains visually hidden while screen-reader friendly
- replace generic AI SME media thumbnail alt text with descriptions that reflect each video

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c941c250148330adae19986075987d