### PR TITLE
Use relative path for search index fetch

### DIFF
--- a/shared/scripts/pages/home-search.js
+++ b/shared/scripts/pages/home-search.js
@@ -18,7 +18,7 @@ class GlobalSearch {
 
     async loadSearchIndex() {
         try {
-            const response = await fetch('/shared/search-index.json');
+            const response = await fetch('shared/search-index.json');
             const data = await response.json();
             this.searchData = data.searchIndex.map(item => ({
                 ...item,


### PR DESCRIPTION
## Summary
- update the home search script to request the search index JSON via a relative path so it works when hosted on sub-paths

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68c943b54bd88330a1405d4a3825ef2e