### PR TITLE
Add storage manager utility for RPO training app

### DIFF
--- a/rpo-training/js/app.js
+++ b/rpo-training/js/app.js
@@ -1,4 +1,5 @@
 import { BackToTop } from '../../shared/scripts/gbs-core.js';
+import StorageManager from '../../shared/scripts/utils/storage-manager.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     const mainPage = document.getElementById('main-page');
@@ -126,12 +127,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function navigateTo(pageId) {
         // Store the scroll position if leaving the main page
         if (document.getElementById('main-page').classList.contains('active') && pageId !== 'main-page') {
-            sessionStorage.setItem('mainPageScrollPosition', window.scrollY);
-        }
-
-        // This part seems to be for a different scroll position saving logic, removing it to avoid conflict
-        if (pageId !== 'main-page') {
-            sessionStorage.setItem('scrollPosition', window.scrollY);
+            StorageManager.scroll.save();
         }
 
         // Hide all pages by default
@@ -142,11 +138,8 @@ document.addEventListener('DOMContentLoaded', () => {
             mainPage.classList.add('active');
             sessionContainer.textContent = '';
             // Restore scroll position if returning to the main page
-            const savedPosition = sessionStorage.getItem('mainPageScrollPosition');
-            if (savedPosition) {
-                window.scrollTo(0, parseInt(savedPosition, 10) - 100); // Added -100 for a little buffer above
-                sessionStorage.removeItem('scrollPosition');
-            }
+            StorageManager.scroll.restore();
+            StorageManager.module.clear();
         } else if (pageId.startsWith('module-')) {
             showSessionMenu(pageId);
         } else {
@@ -168,17 +161,12 @@ document.addEventListener('DOMContentLoaded', () => {
                     // Re-attach event listeners for any new buttons in the loaded content if necessary
                     const backButton = sessionContainer.querySelector('button');
                     // Store the current module ID before navigating to a session
-                    const currentModuleId = sessionStorage.getItem('currentModuleId');
-                    if (currentModuleId) {
-                        sessionStorage.setItem('lastVisitedModule', currentModuleId);
-                    }
+                    const currentModuleId = StorageManager.module.getCurrent();
 
                     if (backButton) {
                         backButton.addEventListener('click', () => {
-                            const lastModule = sessionStorage.getItem('lastVisitedModule');
-                            if (lastModule) {
-                                navigateTo(lastModule);
-                                sessionStorage.removeItem('lastVisitedModule'); // Clear after use
+                            if (currentModuleId) {
+                                navigateTo(currentModuleId);
                             } else {
                                 navigateTo('main-page');
                             }
@@ -203,7 +191,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Store the current module ID when navigating to a module session menu
         if (pageId.startsWith('module-')) {
-            sessionStorage.setItem('currentModuleId', pageId);
+            StorageManager.module.setCurrent(pageId);
         }
 
     }

--- a/shared/scripts/utils/storage-manager.js
+++ b/shared/scripts/utils/storage-manager.js
@@ -1,0 +1,128 @@
+/**
+ * StorageManager centralizes access to sessionStorage and normalizes the
+ * configuration used across learning hub experiences.
+ *
+ * Default keys:
+ * - MAIN_PAGE_SCROLL: stores the scroll position of the landing page ("mainPageScrollPosition").
+ * - GENERAL_SCROLL: legacy scroll position key retained for compatibility ("scrollPosition").
+ * - CURRENT_MODULE: keeps track of the active module in the RPO training experience ("currentModuleId").
+ *
+ * Default offsets:
+ * - SCROLL_RESTORE: 100 pixels are subtracted when restoring the main page scroll position to provide visual context above the target.
+ */
+
+const DEFAULT_KEYS = Object.freeze({
+    MAIN_PAGE_SCROLL: 'mainPageScrollPosition',
+    GENERAL_SCROLL: 'scrollPosition',
+    CURRENT_MODULE: 'currentModuleId'
+});
+
+const DEFAULT_OFFSETS = Object.freeze({
+    SCROLL_RESTORE: 100
+});
+
+const isBrowserEnvironment = typeof window !== 'undefined';
+
+const storage = (() => {
+    if (!isBrowserEnvironment) {
+        return null;
+    }
+
+    try {
+        const { sessionStorage } = window;
+        const testKey = '__storage_test__';
+        sessionStorage.setItem(testKey, testKey);
+        sessionStorage.removeItem(testKey);
+        return sessionStorage;
+    } catch (error) {
+        return null;
+    }
+})();
+
+const safeSetItem = (key, value) => {
+    if (!storage) {
+        return;
+    }
+
+    try {
+        storage.setItem(key, String(value));
+    } catch (error) {
+        // Ignore storage errors to avoid breaking navigation in private browsing modes.
+    }
+};
+
+const safeGetItem = key => {
+    if (!storage) {
+        return null;
+    }
+
+    try {
+        return storage.getItem(key);
+    } catch (error) {
+        return null;
+    }
+};
+
+const safeRemoveItem = key => {
+    if (!storage) {
+        return;
+    }
+
+    try {
+        storage.removeItem(key);
+    } catch (error) {
+        // Ignore removal issues for consistency with set operations.
+    }
+};
+
+const StorageManager = {
+    keys: DEFAULT_KEYS,
+    offsets: DEFAULT_OFFSETS,
+    scroll: {
+        save(position = isBrowserEnvironment ? window.scrollY : 0) {
+            const normalizedPosition = Number.isFinite(position) ? position : parseInt(position, 10);
+            const value = Number.isFinite(normalizedPosition) ? Math.max(normalizedPosition, 0) : 0;
+
+            safeSetItem(DEFAULT_KEYS.MAIN_PAGE_SCROLL, value);
+            safeSetItem(DEFAULT_KEYS.GENERAL_SCROLL, value);
+        },
+        restore({ apply = true, offset = DEFAULT_OFFSETS.SCROLL_RESTORE } = {}) {
+            const storedValue = safeGetItem(DEFAULT_KEYS.MAIN_PAGE_SCROLL);
+            if (storedValue === null) {
+                return null;
+            }
+
+            const parsed = parseInt(storedValue, 10);
+            if (!Number.isFinite(parsed)) {
+                return null;
+            }
+
+            const targetPosition = Math.max(parsed - offset, 0);
+
+            safeRemoveItem(DEFAULT_KEYS.GENERAL_SCROLL);
+
+            if (apply && isBrowserEnvironment && typeof window.scrollTo === 'function') {
+                window.scrollTo(0, targetPosition);
+            }
+
+            return targetPosition;
+        }
+    },
+    module: {
+        setCurrent(moduleId) {
+            if (typeof moduleId !== 'string' || !moduleId) {
+                return;
+            }
+
+            safeSetItem(DEFAULT_KEYS.CURRENT_MODULE, moduleId);
+        },
+        getCurrent() {
+            return safeGetItem(DEFAULT_KEYS.CURRENT_MODULE);
+        },
+        clear() {
+            safeRemoveItem(DEFAULT_KEYS.CURRENT_MODULE);
+        }
+    }
+};
+
+export default StorageManager;


### PR DESCRIPTION
## Summary
- add a shared StorageManager helper with documented keys and offsets for scroll and module state
- update the RPO training experience to use the new helper instead of direct sessionStorage access

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c94c6388748330b45b9d0d2e08f99a