### PR TITLE
Simplify footer loading and link updates

### DIFF
--- a/shared/scripts/footer.js
+++ b/shared/scripts/footer.js
@@ -1,35 +1,34 @@
+const getFooterPath = () =>
+    window.location.pathname.includes('/shared/')
+        ? '../shared/footer.html'
+        : './shared/footer.html';
+
 document.addEventListener("DOMContentLoaded", function() {
     const placeholder = document.getElementById('footer-placeholder');
     if (placeholder) {
-        // Determine the path to the footer file based on the current page's depth
-        const path = window.location.pathname;
-        const depth = path.split('/').length - 2; // -2 because of the leading and trailing slash in some cases
-        const relativePath = '../'.repeat(depth > 0 ? depth : 0) + 'shared/footer.html';
+        const footerPath = getFooterPath();
 
-        fetch(relativePath)
+        fetch(footerPath)
             .then(response => response.text())
             .then(data => {
                 placeholder.innerHTML = data;
 
-                // Adjust link paths to be relative to the root
-                const links = placeholder.querySelectorAll('a');
-                const isFileProtocol = window.location.protocol === 'file:';
+                const links = placeholder.querySelectorAll('a[href^="/"]');
+                const prefix = footerPath.replace('shared/footer.html', '');
+                const normalizedPrefix = prefix === './' ? '' : prefix;
 
                 links.forEach(link => {
                     const originalHref = link.getAttribute('href');
-                    if (originalHref && originalHref.startsWith('/')) {
-                        let newHref = originalHref;
-                        if (isFileProtocol) {
-                            // For local file viewing, construct a relative path from the root
-                            const rootPath = window.location.pathname.substring(0, window.location.pathname.lastIndexOf('/shared/'));
-                            newHref = `file://${rootPath}${originalHref}`;
-                        } else {
-                            // For server viewing, root-relative paths are fine
-                             const relativePrefix = '../'.repeat(depth > 0 ? depth : 0);
-                             newHref = relativePrefix.slice(0, -1) + originalHref
-                        }
-                        link.setAttribute('href', newHref);
+                    if (!originalHref) {
+                        return;
                     }
+
+                    if (!normalizedPrefix) {
+                        link.setAttribute('href', originalHref);
+                        return;
+                    }
+
+                    link.setAttribute('href', `${normalizedPrefix}${originalHref.slice(1)}`);
                 });
             })
             .catch(error => console.error('Error loading footer:', error));


### PR DESCRIPTION
## Summary
- add a helper to resolve the footer fragment path based on the current location
- load the footer via the new helper and streamline root-relative link handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c94ec59c5c8330b745c774bb81b87f