### PR TITLE
feat: externalize environment configuration

### DIFF
--- a/gbs-ai-workshop/config/environment.js
+++ b/gbs-ai-workshop/config/environment.js
@@ -1,0 +1,25 @@
+// This file exposes build-time environment variables to the browser. It is
+// populated during the deployment/build step so that client-side code can read
+// configuration without hard-coding secrets.
+(function exposeEnvironment(global) {
+    const processEnv = (typeof process !== 'undefined' && process?.env) || {};
+    const existingEnv = (typeof global !== 'undefined' && typeof global.__ENV__ === 'object' && global.__ENV__) || {};
+
+    const resolvedEnv = {
+        FIREBASE_API_KEY: processEnv.FIREBASE_API_KEY ?? existingEnv.FIREBASE_API_KEY ?? '',
+        FIREBASE_AUTH_DOMAIN: processEnv.FIREBASE_AUTH_DOMAIN ?? existingEnv.FIREBASE_AUTH_DOMAIN ?? '',
+        FIREBASE_PROJECT_ID: processEnv.FIREBASE_PROJECT_ID ?? existingEnv.FIREBASE_PROJECT_ID ?? '',
+        FIREBASE_APP_ID: processEnv.FIREBASE_APP_ID ?? existingEnv.FIREBASE_APP_ID ?? '',
+        FIREBASE_DATABASE_URL: processEnv.FIREBASE_DATABASE_URL ?? existingEnv.FIREBASE_DATABASE_URL ?? '',
+        FIREBASE_STORAGE_BUCKET: processEnv.FIREBASE_STORAGE_BUCKET ?? existingEnv.FIREBASE_STORAGE_BUCKET ?? '',
+        FIREBASE_MESSAGING_SENDER_ID: processEnv.FIREBASE_MESSAGING_SENDER_ID ?? existingEnv.FIREBASE_MESSAGING_SENDER_ID ?? '',
+        FIREBASE_MEASUREMENT_ID: processEnv.FIREBASE_MEASUREMENT_ID ?? existingEnv.FIREBASE_MEASUREMENT_ID ?? '',
+        FIREBASE_COLLECTION_ROOT: processEnv.FIREBASE_COLLECTION_ROOT ?? existingEnv.FIREBASE_COLLECTION_ROOT ?? 'artifacts',
+        APP_ID: processEnv.APP_ID ?? existingEnv.APP_ID ?? existingEnv.FIREBASE_APP_IDENTIFIER ?? '',
+        GOOGLE_AI_API_KEY: processEnv.GOOGLE_AI_API_KEY ?? processEnv.AI_API_KEY ?? existingEnv.GOOGLE_AI_API_KEY ?? '',
+        GOOGLE_AI_API_URL: processEnv.GOOGLE_AI_API_URL ?? processEnv.AI_API_URL ?? existingEnv.GOOGLE_AI_API_URL ?? '',
+        GOOGLE_AI_MODEL: processEnv.GOOGLE_AI_MODEL ?? processEnv.AI_MODEL ?? existingEnv.GOOGLE_AI_MODEL ?? 'gemini-2.0-flash'
+    };
+
+    global.__ENV__ = resolvedEnv;
+})(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));

--- a/gbs-ai-workshop/index.html
+++ b/gbs-ai-workshop/index.html
@@ -1094,6 +1094,7 @@
 
     </main>
 
+    <script src="./config/environment.js"></script>
     <script src="../shared/scripts/smooth-scroll.js" defer></script>
     <script src="../shared/vendor/chart-lite.js" defer></script>
     <script type="module" src="./app.js"></script>

--- a/gbs-ai-workshop/src/sections/ReversePromptSection.js
+++ b/gbs-ai-workshop/src/sections/ReversePromptSection.js
@@ -1,3 +1,5 @@
+import { generateContent, buildReversePromptPayload } from '../services/aiService.js';
+
 export function initReversePromptSection() {
     const generateReversePromptBtn = document.getElementById('generateReversePromptBtn');
     if (!generateReversePromptBtn) return;
@@ -21,24 +23,9 @@ export function initReversePromptSection() {
         outputContainer?.classList.add('hidden');
         errorContainer?.classList.add('hidden');
 
-        const metaPrompt = `You are an expert in prompt engineering. Analyze the following text and generate a high-quality, effective prompt that could have been used to create it. Break down your reasoning, explaining why the prompt you created is effective. The prompt should be structured to include: 1. A clear persona (e.g., 'Act as a...'). 2. A specific task or goal. 3. Instructions on tone and format if they can be inferred from the text. Return your response as a JSON object with two keys: "generated_prompt" and "explanation".\n\nText to analyze:\n---\n${inputText}\n---`;
-
         try {
-            const apiKey = '';
-            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`;
-            const payload = { contents: [{ role: 'user', parts: [{ text: metaPrompt }] }] };
-
-            const response = await fetch(apiUrl, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payload)
-            });
-
-            if (!response.ok) {
-                throw new Error(`API request failed with status ${response.status}`);
-            }
-
-            const result = await response.json();
+            const payload = buildReversePromptPayload(inputText);
+            const result = await generateContent(payload);
             const textOutput = result?.candidates?.[0]?.content?.parts?.[0]?.text;
             if (!textOutput) {
                 throw new Error('Invalid response structure from API.');
@@ -59,7 +46,11 @@ export function initReversePromptSection() {
         } catch (error) {
             console.error('Reverse prompt generation failed:', error);
             if (errorContainer) {
-                errorContainer.textContent = 'Sorry, something went wrong while generating the prompt. Please try again.';
+                if (error?.code === 'ai/missing-api-key') {
+                    errorContainer.textContent = 'The AI service has not been configured. Please contact your administrator.';
+                } else {
+                    errorContainer.textContent = 'Sorry, something went wrong while generating the prompt. Please try again.';
+                }
                 errorContainer.classList.remove('hidden');
             }
         } finally {

--- a/gbs-ai-workshop/src/services/aiService.js
+++ b/gbs-ai-workshop/src/services/aiService.js
@@ -1,0 +1,117 @@
+const DEFAULT_API_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
+const DEFAULT_MODEL = "gemini-2.0-flash";
+
+let cachedEnvironment = null;
+
+function resolveEnvironment() {
+    if (cachedEnvironment) {
+        return cachedEnvironment;
+    }
+
+    const env = {};
+
+    if (typeof process !== "undefined" && process?.env) {
+        for (const [key, value] of Object.entries(process.env)) {
+            if (typeof value !== "undefined") {
+                env[key] = value;
+            }
+        }
+    }
+
+    const globalEnv = typeof globalThis !== "undefined" && typeof globalThis.__ENV__ === "object"
+        ? globalThis.__ENV__
+        : null;
+
+    if (globalEnv) {
+        Object.assign(env, globalEnv);
+    }
+
+    cachedEnvironment = env;
+    return cachedEnvironment;
+}
+
+export function getAiEnvironment() {
+    return { ...resolveEnvironment() };
+}
+
+export function getAiConfig() {
+    const env = resolveEnvironment();
+    return {
+        apiKey: env.GOOGLE_AI_API_KEY || env.AI_API_KEY || "",
+        apiBaseUrl: env.GOOGLE_AI_API_URL || env.AI_API_URL || DEFAULT_API_BASE_URL,
+        model: env.GOOGLE_AI_MODEL || env.AI_MODEL || DEFAULT_MODEL
+    };
+}
+
+function buildRequestUrl(config) {
+    if (!config.apiKey) {
+        const error = new Error("Missing Google AI API key");
+        error.code = "ai/missing-api-key";
+        throw error;
+    }
+
+    const normalizedBaseUrl = config.apiBaseUrl.replace(/\/+$/, "");
+    const normalizedModel = config.model.replace(/^models\//, "");
+
+    return `${normalizedBaseUrl}/models/${normalizedModel}:generateContent?key=${encodeURIComponent(config.apiKey)}`;
+}
+
+export async function generateContent(promptOrPayload, options = {}) {
+    const config = getAiConfig();
+    const url = buildRequestUrl(config);
+
+    const fetchImpl = options.fetchImpl || (typeof fetch === "function" ? fetch : null);
+    if (typeof fetchImpl !== "function") {
+        throw new Error("A fetch implementation is required to call the AI service.");
+    }
+
+    const payload = typeof promptOrPayload === "string"
+        ? { contents: [{ role: "user", parts: [{ text: promptOrPayload }]}] }
+        : promptOrPayload;
+
+    if (!payload || typeof payload !== "object") {
+        throw new Error("A valid payload must be provided to the AI service.");
+    }
+
+    const response = await fetchImpl(url, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            ...(options.headers || {})
+        },
+        body: JSON.stringify(payload),
+        signal: options.signal
+    });
+
+    if (!response.ok) {
+        let errorBody = null;
+        try {
+            errorBody = await response.text();
+        } catch (readError) {
+            // Ignore body read errors and fall back to status message only.
+        }
+
+        const error = new Error(`AI request failed with status ${response.status}`);
+        error.status = response.status;
+        error.statusText = response.statusText;
+        if (errorBody) {
+            error.body = errorBody;
+        }
+        throw error;
+    }
+
+    return response.json();
+}
+
+export function buildReversePromptPayload(inputText) {
+    const metaPrompt = `You are an expert in prompt engineering. Analyze the following text and generate a high-quality, effective prompt that could have been used to create it. Break down your reasoning, explaining why the prompt you created is effective. The prompt should be structured to include: 1. A clear persona (e.g., 'Act as a...'). 2. A specific task or goal. 3. Instructions on tone and format if they can be inferred from the text. Return your response as a JSON object with two keys: "generated_prompt" and "explanation".\n\nText to analyze:\n---\n${inputText}\n---`;
+
+    return {
+        contents: [
+            {
+                role: "user",
+                parts: [{ text: metaPrompt }]
+            }
+        ]
+    };
+}

--- a/gbs-ai-workshop/src/services/firebase.js
+++ b/gbs-ai-workshop/src/services/firebase.js
@@ -1,0 +1,143 @@
+import { initializeApp } from "../../../shared/vendor/firebase/firebase-app.js";
+import { getAuth } from "../../../shared/vendor/firebase/firebase-auth.js";
+import { getFirestore } from "../../../shared/vendor/firebase/firebase-firestore.js";
+
+const REQUIRED_CONFIG_FIELDS = ["apiKey", "authDomain", "projectId"];
+
+let cachedEnvironment = null;
+let cachedConfig = null;
+let firebaseAppInstance = null;
+let firebaseAuthInstance = null;
+let firebaseDbInstance = null;
+let initializationError = null;
+
+function resolveEnvironment() {
+    if (cachedEnvironment) {
+        return cachedEnvironment;
+    }
+
+    const env = {};
+
+    if (typeof process !== "undefined" && process?.env) {
+        for (const [key, value] of Object.entries(process.env)) {
+            if (typeof value !== "undefined") {
+                env[key] = value;
+            }
+        }
+    }
+
+    const globalEnv = typeof globalThis !== "undefined" && typeof globalThis.__ENV__ === "object"
+        ? globalThis.__ENV__
+        : null;
+
+    if (globalEnv) {
+        Object.assign(env, globalEnv);
+    }
+
+    cachedEnvironment = env;
+    return cachedEnvironment;
+}
+
+function sanitizeConfig(rawEnv) {
+    const config = {
+        apiKey: rawEnv.FIREBASE_API_KEY,
+        authDomain: rawEnv.FIREBASE_AUTH_DOMAIN,
+        projectId: rawEnv.FIREBASE_PROJECT_ID,
+        appId: rawEnv.FIREBASE_APP_ID,
+        databaseURL: rawEnv.FIREBASE_DATABASE_URL,
+        storageBucket: rawEnv.FIREBASE_STORAGE_BUCKET,
+        messagingSenderId: rawEnv.FIREBASE_MESSAGING_SENDER_ID,
+        measurementId: rawEnv.FIREBASE_MEASUREMENT_ID
+    };
+
+    return Object.fromEntries(
+        Object.entries(config).filter(([, value]) => value !== undefined && value !== null && String(value).length > 0)
+    );
+}
+
+function resolveConfig() {
+    if (!cachedConfig) {
+        cachedConfig = sanitizeConfig(resolveEnvironment());
+    }
+    return cachedConfig;
+}
+
+function validateConfig(config) {
+    const missing = REQUIRED_CONFIG_FIELDS.filter((field) => !config[field]);
+    if (missing.length > 0) {
+        const error = new Error(`Missing Firebase configuration values: ${missing.join(", ")}`);
+        error.code = "firebase/missing-config";
+        error.missing = missing;
+        throw error;
+    }
+}
+
+export function getFirebaseEnvironment() {
+    return { ...resolveEnvironment() };
+}
+
+export function getFirebaseConfig() {
+    return { ...resolveConfig() };
+}
+
+export function getAppIdentifier() {
+    const env = resolveEnvironment();
+    return env.APP_ID || env.FIREBASE_APP_IDENTIFIER || "gbs-gemini-training";
+}
+
+export function getCollectionRoot() {
+    const env = resolveEnvironment();
+    return env.FIREBASE_COLLECTION_ROOT || "artifacts";
+}
+
+export function ensureFirebase() {
+    if (firebaseAppInstance) {
+        return {
+            app: firebaseAppInstance,
+            auth: firebaseAuthInstance,
+            db: firebaseDbInstance,
+            config: getFirebaseConfig()
+        };
+    }
+
+    if (initializationError) {
+        throw initializationError;
+    }
+
+    const config = resolveConfig();
+
+    try {
+        validateConfig(config);
+    } catch (error) {
+        initializationError = error;
+        throw error;
+    }
+
+    try {
+        firebaseAppInstance = initializeApp(config);
+        firebaseAuthInstance = getAuth(firebaseAppInstance);
+        firebaseDbInstance = getFirestore(firebaseAppInstance);
+    } catch (error) {
+        initializationError = error;
+        throw error;
+    }
+
+    return {
+        app: firebaseAppInstance,
+        auth: firebaseAuthInstance,
+        db: firebaseDbInstance,
+        config: getFirebaseConfig()
+    };
+}
+
+export function getFirebaseApp() {
+    return ensureFirebase().app;
+}
+
+export function getFirebaseAuth() {
+    return ensureFirebase().auth;
+}
+
+export function getFirebaseDb() {
+    return ensureFirebase().db;
+}


### PR DESCRIPTION
## Summary
- expose build-time environment variables to the browser via `config/environment.js`
- add Firebase and AI service modules that initialize from environment-driven configuration
- update feature modules to consume the shared services and surface configuration errors gracefully
- load the environment bootstrap script from `index.html`

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c96158bbb48330a9afde84f0406e09