### PR TITLE
Lazy load workshop data modules

### DIFF
--- a/gbs-ai-workshop/app.js
+++ b/gbs-ai-workshop/app.js
@@ -25,15 +25,14 @@ document.addEventListener('DOMContentLoaded', async () => {
         container.classList.add('hidden');
     };
 
-    initWhySection();
-    initHowSection();
-    initPromptLibrarySection();
-    initPromptBuilderSection();
-    initReversePromptSection();
-    initMyLibrarySection();
-
     const navigation = initNavigation({
         sectionInitializers: {
+            why: initWhySection,
+            how: initHowSection,
+            what: initPromptLibrarySection,
+            builder: initPromptBuilderSection,
+            'reverse-prompt': initReversePromptSection,
+            'my-library': initMyLibrarySection,
             'case-studies': initCaseStudiesSection,
             simulator: initSimulatorSection,
             'my-day': initMyDaySection

--- a/gbs-ai-workshop/src/data/loaders.js
+++ b/gbs-ai-workshop/src/data/loaders.js
@@ -1,0 +1,57 @@
+const dataCache = new Map();
+
+function loadData(key, importer) {
+    if (!dataCache.has(key)) {
+        const promise = importer().catch((error) => {
+            dataCache.delete(key);
+            throw error;
+        });
+        dataCache.set(key, promise);
+    }
+    return dataCache.get(key);
+}
+
+export function loadPromptsData() {
+    return loadData('prompts', async () => {
+        const module = await import('./prompts.js');
+        return Array.isArray(module.prompts) ? module.prompts : [];
+    });
+}
+
+export function loadScenarios() {
+    return loadData('scenarios', async () => {
+        const module = await import('./scenarios.js');
+        return module.scenarios ?? {};
+    });
+}
+
+export function loadMyDayEvents() {
+    return loadData('myDayEvents', async () => {
+        const module = await import('./myDayEvents.js');
+        return Array.isArray(module.myDayEvents) ? module.myDayEvents : [];
+    });
+}
+
+export function loadCaseStudies() {
+    return loadData('caseStudies', async () => {
+        const module = await import('./caseStudies.js');
+        return module.caseStudies ?? {};
+    });
+}
+
+export function loadOpportunityData() {
+    return loadData('opportunityData', async () => {
+        const module = await import('./opportunityData.js');
+        return {
+            opportunityData: module.opportunityData,
+            opportunityDetailsData: module.opportunityDetailsData
+        };
+    });
+}
+
+export function loadWhySubtitles() {
+    return loadData('whySubtitles', async () => {
+        const module = await import('./whySubtitles.js');
+        return Array.isArray(module.whySubtitles) ? module.whySubtitles : [];
+    });
+}

--- a/gbs-ai-workshop/src/data/whySubtitles.js
+++ b/gbs-ai-workshop/src/data/whySubtitles.js
@@ -1,0 +1,5 @@
+export const whySubtitles = [
+    'Automate Tedious Reports...',
+    'Summarize Long Meetings...',
+    'Draft Professional Emails...'
+];

--- a/gbs-ai-workshop/src/sections/WhySection.js
+++ b/gbs-ai-workshop/src/sections/WhySection.js
@@ -1,30 +1,50 @@
+import { loadWhySubtitles } from '../data/loaders.js';
+
 let subtitleIntervalId;
+let isLoading = false;
 
-export function initWhySection() {
+export async function initWhySection() {
     const subtitleElement = document.getElementById('animated-subtitle');
-    if (!subtitleElement || subtitleIntervalId) return;
+    if (!subtitleElement || subtitleIntervalId || isLoading) return;
 
-    const subtitles = [
-        'Automate Tedious Reports...',
-        'Summarize Long Meetings...',
-        'Draft Professional Emails...'
-    ];
-    let subtitleIndex = 0;
+    isLoading = true;
+    subtitleElement.textContent = 'Loading inspiration...';
+    subtitleElement.classList.add('text-gray-400', 'animate-pulse');
 
-    const cycleSubtitles = () => {
-        subtitleElement.classList.remove('subtitle-animate-in');
-        subtitleElement.classList.add('subtitle-animate-out');
+    try {
+        const subtitles = await loadWhySubtitles();
+        if (!Array.isArray(subtitles) || subtitles.length === 0) {
+            subtitleElement.textContent = '';
+            subtitleElement.classList.remove('animate-pulse', 'text-gray-400');
+            return;
+        }
 
-        setTimeout(() => {
-            subtitleIndex = (subtitleIndex + 1) % subtitles.length;
-            subtitleElement.textContent = subtitles[subtitleIndex];
-            subtitleElement.classList.remove('subtitle-animate-out');
-            subtitleElement.classList.add('subtitle-animate-in');
-        }, 500);
-    };
+        let subtitleIndex = 0;
 
-    subtitleElement.textContent = subtitles[0];
-    subtitleElement.classList.add('subtitle-animate-in');
+        const cycleSubtitles = () => {
+            subtitleElement.classList.remove('subtitle-animate-in');
+            subtitleElement.classList.add('subtitle-animate-out');
 
-    subtitleIntervalId = window.setInterval(cycleSubtitles, 4000);
+            window.setTimeout(() => {
+                subtitleIndex = (subtitleIndex + 1) % subtitles.length;
+                subtitleElement.textContent = subtitles[subtitleIndex];
+                subtitleElement.classList.remove('subtitle-animate-out');
+                subtitleElement.classList.add('subtitle-animate-in');
+            }, 500);
+        };
+
+        subtitleElement.textContent = subtitles[0];
+        subtitleElement.classList.remove('animate-pulse', 'text-gray-400');
+        subtitleElement.classList.add('subtitle-animate-in');
+
+        subtitleIntervalId = window.setInterval(cycleSubtitles, 4000);
+    } catch (error) {
+        console.error('Failed to load Why section subtitles', error);
+        subtitleElement.textContent = 'Unable to load examples right now.';
+        subtitleElement.classList.remove('subtitle-animate-in', 'subtitle-animate-out');
+        subtitleElement.classList.remove('animate-pulse', 'text-gray-400');
+        subtitleElement.classList.add('text-gray-500');
+    } finally {
+        isLoading = false;
+    }
 }


### PR DESCRIPTION
## Summary
- add shared data loaders and a dedicated subtitles data file for the workshop experience
- refactor workshop sections to load prompts, case studies, scenarios, chart data, and subtitles on demand with visible loading and error states
- wire navigation so each section initializes lazily when opened instead of at page load

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c969c40e7483308887a26c02e0a1bc