### PR TITLE
Refactor workshop sections to use reusable components

### DIFF
--- a/gbs-ai-workshop/src/components/PromptBuilder.js
+++ b/gbs-ai-workshop/src/components/PromptBuilder.js
@@ -1,0 +1,181 @@
+const DEFAULT_BUTTON_RESET_DELAY = 2000;
+
+export class PromptBuilder {
+    constructor({
+        fieldIds = {},
+        outputId,
+        outputContainerId,
+        buttons = {},
+        onSave
+    } = {}) {
+        this.fieldIds = {
+            goal: fieldIds.goal ?? null,
+            audience: fieldIds.audience ?? null,
+            tone: fieldIds.tone ?? null,
+            format: fieldIds.format ?? null,
+            context: fieldIds.context ?? null
+        };
+
+        this.outputId = outputId;
+        this.outputContainerId = outputContainerId;
+        this.buttonIds = {
+            generate: buttons.generate ?? null,
+            save: buttons.save ?? null,
+            copy: buttons.copy ?? null
+        };
+
+        this.handlers = {
+            onSave: typeof onSave === 'function' ? onSave : null
+        };
+
+        this.elements = {
+            fields: {},
+            output: null,
+            outputContainer: null,
+            buttons: {}
+        };
+
+        this.initialized = false;
+
+        this.handleGenerate = this.handleGenerate.bind(this);
+        this.handleSave = this.handleSave.bind(this);
+        this.handleCopy = this.handleCopy.bind(this);
+    }
+
+    init() {
+        if (this.initialized) return;
+
+        this.captureElements();
+        this.attachEventListeners();
+
+        this.initialized = true;
+    }
+
+    captureElements() {
+        Object.entries(this.fieldIds).forEach(([key, id]) => {
+            if (id) {
+                this.elements.fields[key] = document.getElementById(id);
+            }
+        });
+
+        if (this.outputId) {
+            this.elements.output = document.getElementById(this.outputId);
+        }
+
+        if (this.outputContainerId) {
+            this.elements.outputContainer = document.getElementById(this.outputContainerId);
+        }
+
+        Object.entries(this.buttonIds).forEach(([key, id]) => {
+            if (id) {
+                this.elements.buttons[key] = document.getElementById(id);
+            }
+        });
+    }
+
+    attachEventListeners() {
+        const { generate, save, copy } = this.elements.buttons;
+
+        generate?.addEventListener('click', this.handleGenerate);
+        save?.addEventListener('click', this.handleSave);
+        copy?.addEventListener('click', this.handleCopy);
+    }
+
+    handleGenerate() {
+        const goal = this.getFieldValue('goal');
+        const audience = this.getFieldValue('audience');
+        const tone = this.getFieldValue('tone');
+        const format = this.getFieldValue('format');
+        const context = this.getFieldValue('context').trim();
+
+        if (!context) {
+            console.warn('Please provide some context for your prompt.');
+            return;
+        }
+
+        const promptText = this.buildPrompt({ goal, audience, tone, format, context });
+        if (this.elements.output) {
+            this.elements.output.textContent = promptText;
+        }
+
+        this.elements.outputContainer?.classList.remove('hidden');
+    }
+
+    async handleSave() {
+        if (!this.handlers.onSave) return;
+
+        const content = this.elements.output?.textContent?.trim();
+        if (!content) return;
+
+        const goal = this.getFieldValue('goal');
+        const button = this.elements.buttons.save;
+        const originalText = button?.textContent ?? '';
+
+        try {
+            await this.handlers.onSave({
+                title: goal ? `Custom: ${goal}` : 'Custom Prompt',
+                content
+            });
+
+            if (button) {
+                button.textContent = 'Saved!';
+                setTimeout(() => {
+                    button.textContent = originalText || 'Save';
+                }, DEFAULT_BUTTON_RESET_DELAY);
+            }
+        } catch (error) {
+            console.error('Failed to save prompt to library', error);
+            if (button) {
+                button.textContent = 'Try Again';
+                setTimeout(() => {
+                    button.textContent = originalText || 'Save';
+                }, DEFAULT_BUTTON_RESET_DELAY);
+            }
+        }
+    }
+
+    handleCopy() {
+        const content = this.elements.output?.textContent ?? '';
+        if (!content) return;
+
+        const button = this.elements.buttons.copy;
+        const originalText = button?.textContent ?? '';
+
+        if (typeof navigator === 'undefined'
+            || !navigator.clipboard
+            || typeof navigator.clipboard.writeText !== 'function') {
+            console.error('Clipboard API is not available in this browser.');
+            return;
+        }
+
+        navigator.clipboard.writeText(content).then(() => {
+            if (button) {
+                button.textContent = 'Copied!';
+                setTimeout(() => {
+                    button.textContent = originalText || 'Copy';
+                }, DEFAULT_BUTTON_RESET_DELAY);
+            }
+        }).catch((error) => {
+            console.error('Failed to copy text:', error);
+        });
+    }
+
+    getFieldValue(fieldKey) {
+        const field = this.elements.fields[fieldKey];
+        if (!field) return '';
+        if ('value' in field) {
+            return field.value ?? '';
+        }
+        return '';
+    }
+
+    buildPrompt({ goal = '', audience = '', tone = '', format = '', context = '' }) {
+        return `Act as an expert GBS Manager. Your task is to ${goal.toLowerCase()}. The audience is ${audience.toLowerCase()}. The tone of the response should be ${tone.toLowerCase()} and the output must be in the format of ${format.toLowerCase()}.
+
+Based on these requirements, please process the following context:
+
+---
+${context}
+---`;
+    }
+}

--- a/gbs-ai-workshop/src/components/PromptExplorer.js
+++ b/gbs-ai-workshop/src/components/PromptExplorer.js
@@ -1,0 +1,236 @@
+const DEFAULT_MESSAGES = {
+    loading: 'Loading prompts...',
+    empty: 'No prompts available.',
+    emptyFilter: 'No prompts found for this filter.',
+    error: 'Unable to load prompts right now.'
+};
+
+export class PromptExplorer {
+    constructor({
+        containerId,
+        filterButtonSelector,
+        loadPrompts,
+        onAddFavorite,
+        onRemoveFavorite,
+        messages = {}
+    } = {}) {
+        this.containerId = containerId;
+        this.filterButtonSelector = filterButtonSelector;
+        this.loadPromptsFn = typeof loadPrompts === 'function' ? loadPrompts : null;
+        this.handlers = {
+            onAddFavorite: typeof onAddFavorite === 'function' ? onAddFavorite : null,
+            onRemoveFavorite: typeof onRemoveFavorite === 'function' ? onRemoveFavorite : null
+        };
+        this.messages = { ...DEFAULT_MESSAGES, ...messages };
+
+        this.state = {
+            prompts: [],
+            library: [],
+            filter: 'All',
+            loading: false,
+            loaded: false,
+            error: null
+        };
+
+        this.initialized = false;
+        this.container = null;
+        this.filterButtons = [];
+
+        this.handleFilterClick = this.handleFilterClick.bind(this);
+        this.handleContainerClick = this.handleContainerClick.bind(this);
+    }
+
+    async init() {
+        if (!this.initialized) {
+            this.container = this.containerId ? document.getElementById(this.containerId) : null;
+            if (!this.container) {
+                return;
+            }
+
+            if (this.filterButtonSelector) {
+                this.filterButtons = Array.from(document.querySelectorAll(this.filterButtonSelector));
+                this.filterButtons.forEach((button) => {
+                    button.addEventListener('click', this.handleFilterClick);
+                });
+                const activeButton = this.filterButtons.find((button) => button.classList.contains('active'));
+                if (activeButton) {
+                    const activeFilter = activeButton.getAttribute('data-filter')?.trim()
+                        || activeButton.textContent?.trim();
+                    if (activeFilter) {
+                        this.state.filter = activeFilter;
+                    }
+                } else if (this.filterButtons.length) {
+                    const defaultFilter = this.filterButtons[0].getAttribute('data-filter')?.trim()
+                        || this.filterButtons[0].textContent?.trim();
+                    if (defaultFilter) {
+                        this.state.filter = defaultFilter;
+                    }
+                    this.updateFilterButtonStyles(this.filterButtons[0]);
+                }
+            }
+
+            this.container.addEventListener('click', this.handleContainerClick);
+            this.initialized = true;
+        }
+
+        if (!this.container) return;
+
+        if (this.state.loaded) {
+            this.render();
+            return;
+        }
+
+        if (this.state.loading) {
+            return;
+        }
+
+        this.renderLoading();
+        await this.fetchPrompts();
+    }
+
+    setLibrary(libraryEntries) {
+        this.state.library = Array.isArray(libraryEntries) ? libraryEntries : [];
+        if (this.initialized && this.state.loaded && !this.state.loading) {
+            this.render();
+        }
+    }
+
+    async fetchPrompts() {
+        if (!this.loadPromptsFn || this.state.loading) return;
+
+        this.state.loading = true;
+        this.state.error = null;
+
+        try {
+            const prompts = await this.loadPromptsFn();
+            this.state.prompts = Array.isArray(prompts) ? prompts : [];
+            this.state.loaded = true;
+        } catch (error) {
+            console.error('Failed to load prompts data', error);
+            this.state.error = error;
+        } finally {
+            this.state.loading = false;
+            this.render();
+        }
+    }
+
+    handleFilterClick(event) {
+        event.preventDefault();
+        const button = event.currentTarget ?? event.target;
+        if (!button) return;
+
+        const filterValue = button.getAttribute('data-filter')?.trim()
+            || button.textContent?.trim()
+            || 'All';
+
+        this.state.filter = filterValue;
+        this.updateFilterButtonStyles(button);
+        if (this.state.loaded && !this.state.loading) {
+            this.renderPrompts();
+        }
+    }
+
+    handleContainerClick(event) {
+        if (!this.container) return;
+        const favoriteButton = event.target.closest('[data-favorite-id]');
+        if (!favoriteButton) return;
+
+        const promptId = favoriteButton.getAttribute('data-favorite-id');
+        if (!promptId) return;
+
+        const favoriteEntry = this.state.library.find((entry) => entry.type === 'favorite' && entry.originalId === promptId);
+        if (favoriteEntry) {
+            this.handlers.onRemoveFavorite?.(favoriteEntry.id, promptId);
+        } else {
+            this.handlers.onAddFavorite?.(promptId);
+        }
+    }
+
+    updateFilterButtonStyles(activeButton) {
+        if (!Array.isArray(this.filterButtons) || !this.filterButtons.length) return;
+
+        this.filterButtons.forEach((button) => {
+            button.classList.remove('active', 'bg-[#4A90E2]', 'text-white');
+            button.classList.add('bg-white', 'text-gray-700');
+        });
+
+        if (activeButton) {
+            activeButton.classList.add('active', 'bg-[#4A90E2]', 'text-white');
+            activeButton.classList.remove('bg-white', 'text-gray-700');
+        }
+    }
+
+    render() {
+        if (!this.container) return;
+
+        if (this.state.error) {
+            this.container.innerHTML = `<div class="col-span-full text-center text-red-500 py-8">${this.messages.error}</div>`;
+            return;
+        }
+
+        if (!this.state.loaded) {
+            this.renderLoading();
+            return;
+        }
+
+        this.renderPrompts();
+    }
+
+    renderLoading() {
+        if (!this.container) return;
+        this.container.innerHTML = `<div class="col-span-full text-center text-gray-500 py-8 animate-pulse">${this.messages.loading}</div>`;
+    }
+
+    renderPrompts() {
+        if (!this.container) return;
+
+        const filteredPrompts = this.getFilteredPrompts();
+
+        if (!this.state.prompts.length) {
+            this.container.innerHTML = `<div class="col-span-full text-center text-gray-500 py-8">${this.messages.empty}</div>`;
+            return;
+        }
+
+        if (!filteredPrompts.length) {
+            this.container.innerHTML = `<div class="col-span-full text-center text-gray-500 py-8">${this.messages.emptyFilter}</div>`;
+            return;
+        }
+
+        const fragment = document.createDocumentFragment();
+        filteredPrompts.forEach((prompt) => {
+            const card = this.createPromptCard(prompt);
+            fragment.appendChild(card);
+        });
+
+        this.container.innerHTML = '';
+        this.container.appendChild(fragment);
+    }
+
+    getFilteredPrompts() {
+        if (this.state.filter === 'All') {
+            return this.state.prompts;
+        }
+        return this.state.prompts.filter((prompt) => prompt.category === this.state.filter);
+    }
+
+    createPromptCard(prompt) {
+        const card = document.createElement('div');
+        card.className = 'prompt-card bg-white p-6 rounded-lg shadow-sm';
+
+        const isFavorited = this.state.library.some((entry) => entry.type === 'favorite' && entry.originalId === prompt.id);
+
+        card.innerHTML = `
+            <div>
+                <h4 class="font-bold text-lg mb-2 text-[#4A90E2]">${prompt.title}</h4>
+                <p class="text-gray-600 text-sm">${prompt.content}</p>
+            </div>
+            <div class="mt-4 pt-4 border-t border-gray-100 flex justify-end items-center">
+                <svg data-favorite-id="${prompt.id}" class="favorite-btn h-6 w-6 ${isFavorited ? 'favorited' : ''}" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                    <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"></path>
+                </svg>
+            </div>
+        `;
+
+        return card;
+    }
+}

--- a/gbs-ai-workshop/src/components/ScenarioSimulator.js
+++ b/gbs-ai-workshop/src/components/ScenarioSimulator.js
@@ -1,0 +1,235 @@
+const DEFAULT_MESSAGES = {
+    loading: 'Loading scenarios...',
+    error: "We couldn't load scenarios right now. Please try again later.",
+    empty: 'No simulator scenarios available yet.',
+    completed: "You've completed all scenarios in this category!"
+};
+
+export class ScenarioSimulator {
+    constructor({
+        containerId,
+        loadScenarios,
+        messages = {}
+    } = {}) {
+        this.containerId = containerId;
+        this.loadScenariosFn = typeof loadScenarios === 'function' ? loadScenarios : null;
+        this.messages = { ...DEFAULT_MESSAGES, ...messages };
+
+        this.state = {
+            scenarios: {},
+            currentCategory: null,
+            currentIndex: 0,
+            loading: false,
+            loaded: false,
+            error: null
+        };
+
+        this.container = null;
+        this.initialized = false;
+        this.handleClick = this.handleClick.bind(this);
+    }
+
+    async init() {
+        if (!this.initialized) {
+            this.container = this.containerId ? document.getElementById(this.containerId) : null;
+            if (!this.container) {
+                return;
+            }
+
+            this.container.addEventListener('click', this.handleClick);
+            this.initialized = true;
+        }
+
+        if (!this.container) return;
+
+        if (this.state.loaded) {
+            this.render();
+            return;
+        }
+
+        if (this.state.loading) {
+            return;
+        }
+
+        this.renderLoading();
+        await this.fetchScenarios();
+    }
+
+    async fetchScenarios() {
+        if (!this.loadScenariosFn) return;
+
+        this.state.loading = true;
+        this.state.error = null;
+
+        try {
+            const scenarios = await this.loadScenariosFn();
+            this.state.scenarios = scenarios && typeof scenarios === 'object' ? scenarios : {};
+            this.state.loaded = true;
+            this.state.currentCategory = null;
+            this.state.currentIndex = 0;
+            this.render();
+        } catch (error) {
+            console.error('Failed to load simulator scenarios', error);
+            this.state.error = error;
+            this.renderError();
+        } finally {
+            this.state.loading = false;
+        }
+    }
+
+    render() {
+        if (!this.container) return;
+
+        if (this.state.error) {
+            this.renderError();
+            return;
+        }
+
+        if (!this.state.loaded) {
+            this.renderLoading();
+            return;
+        }
+
+        if (!this.state.currentCategory) {
+            this.renderCategoryMenu();
+        } else {
+            this.renderScenario();
+        }
+    }
+
+    renderLoading() {
+        if (!this.container) return;
+        this.container.innerHTML = `<div class="text-center text-gray-500 py-8 animate-pulse">${this.messages.loading}</div>`;
+    }
+
+    renderError() {
+        if (!this.container) return;
+        this.container.innerHTML = `<div class="text-center text-red-500 py-8">${this.messages.error}</div>`;
+    }
+
+    renderCategoryMenu() {
+        if (!this.container) return;
+
+        const categories = Object.keys(this.state.scenarios ?? {});
+        if (!categories.length) {
+            this.container.innerHTML = `<div class="text-center text-gray-500 py-8">${this.messages.empty}</div>`;
+            return;
+        }
+
+        const categoryHtml = categories.map((category) => `
+            <div class="category-option p-6 rounded-lg cursor-pointer text-center" data-category="${category}">
+                <h3 class="font-bold text-xl text-[#4A90E2]">${category}</h3>
+            </div>
+        `).join('');
+
+        this.container.innerHTML = `
+            <h3 class="text-2xl font-bold text-center mb-6">Choose a Scenario Category</h3>
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">${categoryHtml}</div>
+        `;
+    }
+
+    renderScenario() {
+        if (!this.container || !this.state.currentCategory) return;
+
+        const scenarios = this.state.scenarios[this.state.currentCategory] ?? [];
+        const scenario = scenarios[this.state.currentIndex];
+
+        if (!scenario) {
+            this.container.innerHTML = `
+                <p class="text-center text-gray-600 text-xl">${this.messages.completed}</p>
+                <div class="mt-6 text-center">
+                    <button id="backToCategoriesBtn" class="bg-gray-600 text-white font-bold py-2 px-6 rounded-full hover:bg-gray-700 transition-colors">Back to Categories</button>
+                </div>
+            `;
+            return;
+        }
+
+        const optionsHtml = scenario.prompts.map((prompt, index) => `
+            <div class="scenario-option p-4 rounded-lg cursor-pointer" data-index="${index}">
+                <p class="font-semibold">${prompt.text}</p>
+                <div class="feedback mt-2 text-sm hidden"></div>
+            </div>
+        `).join('');
+
+        this.container.innerHTML = `
+            <div class="flex justify-between items-center mb-4">
+                <h3 class="text-2xl font-bold text-[#4A90E2]">${scenario.title}</h3>
+                <button id="backToCategoriesBtn" class="text-sm text-gray-500 hover:text-gray-800">&larr; Back to Categories</button>
+            </div>
+            <p class="text-gray-600 mb-6">${scenario.problem}</p>
+            <div class="space-y-4">${optionsHtml}</div>
+            <div class="mt-6 text-right">
+                <button id="nextScenarioBtn" class="hidden bg-[#4A90E2] text-white font-bold py-2 px-6 rounded-full hover:bg-blue-600 transition-colors">Next Scenario</button>
+            </div>
+        `;
+    }
+
+    handleClick(event) {
+        const categoryCard = event.target.closest('.category-option');
+        if (categoryCard) {
+            const category = categoryCard.getAttribute('data-category');
+            this.state.currentCategory = category ?? null;
+            this.state.currentIndex = 0;
+            this.render();
+            return;
+        }
+
+        const backButton = event.target.closest('#backToCategoriesBtn');
+        if (backButton) {
+            this.state.currentCategory = null;
+            this.state.currentIndex = 0;
+            this.render();
+            return;
+        }
+
+        const optionElement = event.target.closest('.scenario-option');
+        if (optionElement) {
+            this.handleScenarioSelection(optionElement);
+            return;
+        }
+
+        if (event.target.id === 'nextScenarioBtn') {
+            this.state.currentIndex += 1;
+            this.renderScenario();
+        }
+    }
+
+    handleScenarioSelection(optionElement) {
+        if (!this.container || optionElement.classList.contains('selected')) return;
+
+        const selectedIndex = Number.parseInt(optionElement.getAttribute('data-index') ?? '0', 10);
+        const scenario = this.getCurrentScenario();
+        const prompts = scenario?.prompts ?? [];
+        const selectedPrompt = prompts[selectedIndex];
+        if (!selectedPrompt) return;
+
+        const allOptions = this.container.querySelectorAll('.scenario-option');
+        allOptions.forEach((option) => option.classList.add('selected'));
+
+        const feedbackEl = optionElement.querySelector('.feedback');
+        if (feedbackEl) {
+            feedbackEl.textContent = selectedPrompt.feedback;
+            feedbackEl.classList.remove('hidden');
+        }
+
+        if (selectedPrompt.isCorrect) {
+            optionElement.classList.add('correct');
+        } else {
+            optionElement.classList.add('incorrect');
+            const correctIndex = prompts.findIndex((prompt) => prompt.isCorrect);
+            if (correctIndex !== -1) {
+                const correctOption = this.container.querySelector(`.scenario-option[data-index='${correctIndex}']`);
+                correctOption?.classList.add('correct');
+            }
+        }
+
+        const nextButton = this.container.querySelector('#nextScenarioBtn');
+        nextButton?.classList.remove('hidden');
+    }
+
+    getCurrentScenario() {
+        if (!this.state.currentCategory) return null;
+        const scenarios = this.state.scenarios[this.state.currentCategory] ?? [];
+        return scenarios[this.state.currentIndex] ?? null;
+    }
+}

--- a/gbs-ai-workshop/src/sections/PromptBuilderSection.js
+++ b/gbs-ai-workshop/src/sections/PromptBuilderSection.js
@@ -1,67 +1,35 @@
+import { PromptBuilder } from '../components/PromptBuilder.js';
 import { addPromptToLibrary } from '../services/firebaseService.js';
 
+let promptBuilder;
+
 export function initPromptBuilderSection() {
-    const generatePromptBtn = document.getElementById('generatePromptBtn');
-    const saveToLibraryBtn = document.getElementById('saveToLibraryBtn');
-    const copyPromptBtn = document.getElementById('copyPromptBtn');
-
-    if (generatePromptBtn) {
-        generatePromptBtn.addEventListener('click', () => {
-            const goal = document.getElementById('promptGoal')?.value ?? '';
-            const audience = document.getElementById('promptAudience')?.value ?? '';
-            const tone = document.getElementById('promptTone')?.value ?? '';
-            const format = document.getElementById('promptFormat')?.value ?? '';
-            const context = document.getElementById('promptContext')?.value.trim() ?? '';
-
-            if (!context) {
-                console.warn('Please provide some context for your prompt.');
-                return;
+    if (!promptBuilder) {
+        promptBuilder = new PromptBuilder({
+            fieldIds: {
+                goal: 'promptGoal',
+                audience: 'promptAudience',
+                tone: 'promptTone',
+                format: 'promptFormat',
+                context: 'promptContext'
+            },
+            outputId: 'generatedPromptOutput',
+            outputContainerId: 'generatedPromptContainer',
+            buttons: {
+                generate: 'generatePromptBtn',
+                save: 'saveToLibraryBtn',
+                copy: 'copyPromptBtn'
+            },
+            onSave: async ({ title, content }) => {
+                await addPromptToLibrary({
+                    type: 'custom',
+                    title,
+                    content,
+                    createdAt: new Date().toISOString()
+                });
             }
-
-            const promptText = `Act as an expert GBS Manager. Your task is to ${goal.toLowerCase()}. The audience is ${audience.toLowerCase()}. The tone of the response should be ${tone.toLowerCase()} and the output must be in the format of ${format.toLowerCase()}.\n\nBased on these requirements, please process the following context:\n\n---\n${context}\n---`;
-
-            const outputElement = document.getElementById('generatedPromptOutput');
-            if (outputElement) {
-                outputElement.textContent = promptText;
-            }
-
-            const container = document.getElementById('generatedPromptContainer');
-            container?.classList.remove('hidden');
         });
     }
 
-    if (saveToLibraryBtn) {
-        saveToLibraryBtn.addEventListener('click', () => {
-            const content = document.getElementById('generatedPromptOutput')?.textContent;
-            const title = document.getElementById('promptGoal')?.value ?? '';
-
-            if (!content) return;
-
-            addPromptToLibrary({
-                type: 'custom',
-                title: `Custom: ${title}`,
-                content,
-                createdAt: new Date().toISOString()
-            });
-
-            saveToLibraryBtn.textContent = 'Saved!';
-            setTimeout(() => {
-                saveToLibraryBtn.textContent = 'Save';
-            }, 2000);
-        });
-    }
-
-    if (copyPromptBtn) {
-        copyPromptBtn.addEventListener('click', () => {
-            const textToCopy = document.getElementById('generatedPromptOutput')?.textContent ?? '';
-            navigator.clipboard.writeText(textToCopy).then(() => {
-                copyPromptBtn.textContent = 'Copied!';
-                setTimeout(() => {
-                    copyPromptBtn.textContent = 'Copy';
-                }, 2000);
-            }).catch((error) => {
-                console.error('Failed to copy text:', error);
-            });
-        });
-    }
+    promptBuilder.init();
 }

--- a/gbs-ai-workshop/src/sections/PromptLibrarySection.js
+++ b/gbs-ai-workshop/src/sections/PromptLibrarySection.js
@@ -1,125 +1,30 @@
+import { PromptExplorer } from '../components/PromptExplorer.js';
 import { loadPromptsData } from '../data/loaders.js';
 import { addPromptToLibrary, removePromptFromLibrary, onLibraryChange } from '../services/firebaseService.js';
 
-let currentFilter = 'All';
-let promptLibraryElement;
-let libraryState = [];
-let filterButtons = [];
-let promptsData = [];
-let promptsLoaded = false;
-let promptsLoading = false;
-let promptsLoadError = null;
-let isInitialized = false;
+let promptExplorer;
+let unsubscribeLibrary = null;
 
 export function initPromptLibrarySection() {
-    if (isInitialized) return;
-
-    promptLibraryElement = document.getElementById('prompt-library');
-    if (!promptLibraryElement) return;
-
-    filterButtons = Array.from(document.querySelectorAll('.prompt-filter-btn'));
-    filterButtons.forEach((button) => {
-        button.addEventListener('click', () => {
-            filterButtons.forEach((btn) => {
-                btn.classList.remove('active', 'bg-[#4A90E2]', 'text-white');
-                btn.classList.add('bg-white', 'text-gray-700');
-            });
-            button.classList.add('active', 'bg-[#4A90E2]', 'text-white');
-            button.classList.remove('bg-white', 'text-gray-700');
-            currentFilter = button.textContent.trim();
-            renderPromptLibrary();
+    if (!promptExplorer) {
+        promptExplorer = new PromptExplorer({
+            containerId: 'prompt-library',
+            filterButtonSelector: '.prompt-filter-btn',
+            loadPrompts: loadPromptsData,
+            onAddFavorite: (promptId) => {
+                addPromptToLibrary({ type: 'favorite', originalId: promptId });
+            },
+            onRemoveFavorite: (libraryId) => {
+                removePromptFromLibrary(libraryId);
+            }
         });
-    });
-
-    promptLibraryElement.addEventListener('click', (event) => {
-        const favoriteButton = event.target.closest('[data-favorite-id]');
-        if (!favoriteButton) return;
-        const promptId = favoriteButton.getAttribute('data-favorite-id');
-        const existing = libraryState.find((entry) => entry.type === 'favorite' && entry.originalId === promptId);
-        if (existing) {
-            removePromptFromLibrary(existing.id);
-        } else {
-            addPromptToLibrary({ type: 'favorite', originalId: promptId });
-        }
-    });
-
-    onLibraryChange((library) => {
-        libraryState = library;
-        renderPromptLibrary();
-    });
-
-    isInitialized = true;
-
-    setLoadingState('Loading prompts...');
-    void loadPrompts();
-}
-
-function renderPromptLibrary() {
-    if (!promptLibraryElement) return;
-
-    if (!promptsLoaded) {
-        if (promptsLoadError) {
-            promptLibraryElement.innerHTML = `<div class="col-span-full text-center text-red-500 py-8">Unable to load prompts right now.</div>`;
-        } else if (promptsLoading) {
-            setLoadingState('Loading prompts...');
-        } else {
-            promptLibraryElement.innerHTML = `<div class="col-span-full text-center text-gray-500 py-8">No prompts available.</div>`;
-        }
-        return;
     }
 
-    const filteredPrompts = currentFilter === 'All'
-        ? promptsData
-        : promptsData.filter((prompt) => prompt.category === currentFilter);
+    void promptExplorer.init();
 
-    if (!filteredPrompts.length) {
-        promptLibraryElement.innerHTML = `<div class="col-span-full text-center text-gray-500 py-8">No prompts found for this filter.</div>`;
-        return;
-    }
-
-    promptLibraryElement.innerHTML = '';
-    filteredPrompts.forEach((prompt) => {
-        const isFavorited = libraryState.some((entry) => entry.type === 'favorite' && entry.originalId === prompt.id);
-        const card = createPromptCard(prompt, isFavorited);
-        promptLibraryElement.appendChild(card);
-    });
-}
-
-function createPromptCard(prompt, isFavorited) {
-    const card = document.createElement('div');
-    card.className = 'prompt-card bg-white p-6 rounded-lg shadow-sm';
-    card.innerHTML = `
-        <div>
-            <h4 class="font-bold text-lg mb-2 text-[#4A90E2]">${prompt.title}</h4>
-            <p class="text-gray-600 text-sm">${prompt.content}</p>
-        </div>
-        <div class="mt-4 pt-4 border-t border-gray-100 flex justify-end items-center">
-            <svg data-favorite-id="${prompt.id}" class="favorite-btn h-6 w-6 ${isFavorited ? 'favorited' : ''}" fill="currentColor" viewBox="0 0 20 20">
-                <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"></path>
-            </svg>
-        </div>
-    `;
-    return card;
-}
-
-function setLoadingState(message) {
-    if (!promptLibraryElement) return;
-    promptLibraryElement.innerHTML = `<div class="col-span-full text-center text-gray-500 py-8 animate-pulse">${message}</div>`;
-}
-
-async function loadPrompts() {
-    if (promptsLoaded || promptsLoading) return;
-    promptsLoading = true;
-    promptsLoadError = null;
-
-    try {
-        promptsData = await loadPromptsData();
-        promptsLoaded = true;
-    } catch (error) {
-        promptsLoadError = error;
-        console.error('Failed to load prompts data', error);
-    } finally {
-        promptsLoading = false;
-        renderPromptLibrary();
+    if (!unsubscribeLibrary) {
+        unsubscribeLibrary = onLibraryChange((library) => {
+            promptExplorer?.setLibrary(library);
+        });
     }
 }

--- a/gbs-ai-workshop/src/sections/SimulatorSection.js
+++ b/gbs-ai-workshop/src/sections/SimulatorSection.js
@@ -1,150 +1,15 @@
+import { ScenarioSimulator } from '../components/ScenarioSimulator.js';
 import { loadScenarios } from '../data/loaders.js';
 
-let simulatorContainer;
-let currentScenarioCategory = null;
-let currentScenarioIndex = 0;
-let scenariosData = {};
-let scenariosLoaded = false;
-let scenariosLoading = false;
-let hasSetup = false;
+let simulator;
 
 export async function initSimulatorSection() {
-    simulatorContainer = document.getElementById('simulator-container');
-    if (!simulatorContainer) return;
-
-    if (!hasSetup) {
-        simulatorContainer.addEventListener('click', handleSimulatorClick);
-        hasSetup = true;
+    if (!simulator) {
+        simulator = new ScenarioSimulator({
+            containerId: 'simulator-container',
+            loadScenarios
+        });
     }
 
-    if (scenariosLoaded) {
-        displayCategoryMenu();
-        return;
-    }
-
-    if (scenariosLoading) return;
-
-    scenariosLoading = true;
-    simulatorContainer.innerHTML = `<div class="text-center text-gray-500 py-8 animate-pulse">Loading scenarios...</div>`;
-
-    try {
-        scenariosData = await loadScenarios();
-        scenariosLoaded = true;
-        displayCategoryMenu();
-    } catch (error) {
-        console.error('Failed to load simulator scenarios', error);
-        simulatorContainer.innerHTML = `<div class="text-center text-red-500 py-8">We couldn't load scenarios right now. Please try again later.</div>`;
-    } finally {
-        scenariosLoading = false;
-    }
-}
-
-function displayCategoryMenu() {
-    if (!simulatorContainer) return;
-    currentScenarioCategory = null;
-    currentScenarioIndex = 0;
-    const categories = Object.keys(scenariosData ?? {});
-
-    if (!categories.length) {
-        simulatorContainer.innerHTML = `<div class="text-center text-gray-500 py-8">No simulator scenarios available yet.</div>`;
-        return;
-    }
-
-    const categoryHtml = categories.map((category) => `
-        <div class="category-option p-6 rounded-lg cursor-pointer text-center" data-category="${category}">
-            <h3 class="font-bold text-xl text-[#4A90E2]">${category}</h3>
-        </div>
-    `).join('');
-
-    simulatorContainer.innerHTML = `
-        <h3 class="text-2xl font-bold text-center mb-6">Choose a Scenario Category</h3>
-        <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">${categoryHtml}</div>
-    `;
-}
-
-function loadScenario() {
-    if (!simulatorContainer || !currentScenarioCategory) return;
-    const scenarioList = scenariosData[currentScenarioCategory];
-    const scenario = scenarioList?.[currentScenarioIndex];
-
-    if (!scenario) {
-        simulatorContainer.innerHTML = `
-            <p class="text-center text-gray-600 text-xl">You've completed all scenarios in this category!</p>
-            <div class="mt-6 text-center">
-                <button id="backToCategoriesBtn" class="bg-gray-600 text-white font-bold py-2 px-6 rounded-full hover:bg-gray-700 transition-colors">Back to Categories</button>
-            </div>
-        `;
-        return;
-    }
-
-    const optionsHtml = scenario.prompts.map((prompt, index) => `
-        <div class="scenario-option p-4 rounded-lg cursor-pointer" data-index="${index}">
-            <p class="font-semibold">${prompt.text}</p>
-            <div class="feedback mt-2 text-sm hidden"></div>
-        </div>
-    `).join('');
-
-    simulatorContainer.innerHTML = `
-        <div class="flex justify-between items-center mb-4">
-            <h3 class="text-2xl font-bold text-[#4A90E2]">${scenario.title}</h3>
-            <button id="backToCategoriesBtn" class="text-sm text-gray-500 hover:text-gray-800">&larr; Back to Categories</button>
-        </div>
-        <p class="text-gray-600 mb-6">${scenario.problem}</p>
-        <div class="space-y-4">${optionsHtml}</div>
-        <div class="mt-6 text-right">
-            <button id="nextScenarioBtn" class="hidden bg-[#4A90E2] text-white font-bold py-2 px-6 rounded-full hover:bg-blue-600 transition-colors">Next Scenario</button>
-        </div>
-    `;
-}
-
-function handleSimulatorClick(event) {
-    const categoryCard = event.target.closest('.category-option');
-    if (categoryCard) {
-        currentScenarioCategory = categoryCard.getAttribute('data-category');
-        currentScenarioIndex = 0;
-        loadScenario();
-        return;
-    }
-
-    const backButton = event.target.closest('#backToCategoriesBtn');
-    if (backButton) {
-        currentScenarioCategory = null;
-        currentScenarioIndex = 0;
-        displayCategoryMenu();
-        return;
-    }
-
-    const optionElement = event.target.closest('.scenario-option');
-    if (optionElement && !optionElement.classList.contains('selected')) {
-        const selectedIndex = parseInt(optionElement.getAttribute('data-index') || '0', 10);
-        const scenario = scenariosData[currentScenarioCategory]?.[currentScenarioIndex];
-        if (!scenario) return;
-
-        const selectedPrompt = scenario.prompts[selectedIndex];
-        const allOptions = simulatorContainer.querySelectorAll('.scenario-option');
-        allOptions.forEach((option) => option.classList.add('selected'));
-
-        const feedbackEl = optionElement.querySelector('.feedback');
-        if (feedbackEl) {
-            feedbackEl.textContent = selectedPrompt.feedback;
-            feedbackEl.classList.remove('hidden');
-        }
-
-        if (selectedPrompt.isCorrect) {
-            optionElement.classList.add('correct');
-        } else {
-            optionElement.classList.add('incorrect');
-            const correctIndex = scenario.prompts.findIndex((prompt) => prompt.isCorrect);
-            const correctOption = simulatorContainer.querySelector(`.scenario-option[data-index='${correctIndex}']`);
-            correctOption?.classList.add('correct');
-        }
-
-        document.getElementById('nextScenarioBtn')?.classList.remove('hidden');
-        return;
-    }
-
-    if (event.target.id === 'nextScenarioBtn') {
-        currentScenarioIndex += 1;
-        loadScenario();
-    }
+    await simulator.init();
 }


### PR DESCRIPTION
## Summary
- add a PromptExplorer component to drive prompt filtering and favorite interactions
- extract prompt builder logic into a dedicated PromptBuilder component
- move simulator rendering and interactions into a ScenarioSimulator component and wire sections to use the new APIs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c973d64f3c83309efa55ce2d99e4be