### PR TITLE
Refactor workshop styling and clean inline styles

### DIFF
--- a/ai-sme/new-page-template.html
+++ b/ai-sme/new-page-template.html
@@ -45,9 +45,9 @@
                 <!-- Text and Headings -->
                 <div>
                     <h2 class="text-3xl font-bold text-ai-heading border-b border-ai-border pb-2 mb-4">Text and Headings</h2>
-                    <p class="text-ai-text mb-4">This is a standard paragraph using <code class="bg-gray-200 text-sm p-1 rounded">.text-ai-text</code>. The main text color is <span style="color:var(--ai-text)">#4A4A4A</span>.</p>
+                    <p class="text-ai-text mb-4">This is a standard paragraph using <code class="bg-gray-200 text-sm p-1 rounded">.text-ai-text</code>. The main text color is <span class="text-ai-text">#4A4A4A</span>.</p>
                     <h3 class="text-2xl font-bold text-ai-heading mb-2">This is a Sub-Heading (h3)</h3>
-                    <p class="text-ai-text mb-4">Headings use <code class="bg-gray-200 text-sm p-1 rounded">.text-ai-heading</code>, which is <span style="color:var(--ai-heading)">#111827</span>.</p>
+                    <p class="text-ai-text mb-4">Headings use <code class="bg-gray-200 text-sm p-1 rounded">.text-ai-heading</code>, which is <span class="text-ai-heading">#111827</span>.</p>
                     <a href="#" class="text-ai-accent hover:underline">This is a link using .text-ai-accent</a>
                 </div>
 

--- a/feedback/get-entry-ids.html
+++ b/feedback/get-entry-ids.html
@@ -16,7 +16,7 @@
         <button onclick="extractEntryIds()">Extract Entry IDs</button>
     </div>
 
-    <div id="results" class="container" style="display: none;">
+    <div id="results" class="container hidden">
         <h3>Step 2: Copy these values to your feedback form</h3>
         <div id="entryIds"></div>
 

--- a/feedback/index.html
+++ b/feedback/index.html
@@ -37,7 +37,7 @@
         <main class="max-w-3xl mx-auto">
             <div class="feedback-form p-8">
                 <!-- Hidden iframe to handle form submission -->
-                <iframe name="hidden_iframe" id="hidden_iframe" style="display:none;" onload="if(submitted) {showSuccessMessage();}"></iframe>
+                <iframe name="hidden_iframe" id="hidden_iframe" class="hidden" onload="if(submitted) {showSuccessMessage();}"></iframe>
 
                 <form id="feedbackForm" class="space-y-6" action="YOUR_GOOGLE_FORM_ACTION_URL" method="POST" target="hidden_iframe">
 

--- a/gbs-ai-workshop/index.html
+++ b/gbs-ai-workshop/index.html
@@ -9,7 +9,8 @@
     <!-- Visualization & Content Choices: 1. Agenda -> App navigation. 2. "4 R's" Audit -> Interactive Doughnut Chart with sliders. 3. Case Study -> Categorized, step-by-step workflow examples. 4. Team Leadership -> Conversation starters, an interactive playbook for handling resistance, and a "Show and Tell" framework. 5. Gemini Prompts -> Filterable cards with favorite button. 6. Prompt Builder -> Step-by-step form to generate and save optimal prompts. 7. Reverse Prompt -> Analyzes text to generate a potential source prompt. 8. My Prompt Library -> User's saved/favorited prompts. 9. Scenario Simulator -> Categorized, interactive problem/solution module. 10. My Day with AI -> "Choose your own adventure" daily task simulator. 11. Framework Image -> HTML/CSS diagram. -->
     <!-- CONFIRMATION: NO SVG graphics used. NO Mermaid JS used. -->
     <link rel="stylesheet" href="../shared/styles/utilities.css">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="styles/main.css">
+    <link rel="stylesheet" href="styles/components.css">
     <link rel="stylesheet" href="../shared/hub-button.css">
     
 </head>

--- a/gbs-ai-workshop/styles/components.css
+++ b/gbs-ai-workshop/styles/components.css
@@ -1,0 +1,50 @@
+.prompt-card {
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+.prompt-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.05), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+}
+
+.scenario-option,
+.category-option {
+    border: 1px solid #e5e7eb;
+    transition: all 0.2s ease-in-out;
+}
+
+.scenario-option:hover,
+.category-option:hover {
+    border-color: #4A90E2;
+    background-color: #eff6ff;
+}
+
+.scenario-option.selected {
+    border-color: #4A90E2;
+    box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.5);
+}
+
+.scenario-option.correct {
+    background-color: #dcfce7;
+    border-color: #22c55e;
+}
+
+.scenario-option.incorrect {
+    background-color: #fee2e2;
+    border-color: #ef4444;
+}
+
+.code-block {
+    background-color: #f3f4f6;
+    border: 1px solid #e5e7eb;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 0.875rem;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    color: #374151;
+}

--- a/gbs-ai-workshop/styles/main.css
+++ b/gbs-ai-workshop/styles/main.css
@@ -3,34 +3,38 @@ body {
     background-color: #F8F7F4;
     color: #4A4A4A;
 }
+
 .nav-link {
     transition: all 0.3s ease;
     border-bottom: 2px solid transparent;
 }
-.nav-link.active, .nav-link:hover {
+
+.nav-link.active,
+.nav-link:hover {
     border-bottom-color: #4A90E2;
     color: #4A90E2;
 }
-.prompt-card {
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-}
-.prompt-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.05), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-}
+
 .fade-in {
     animation: fadeIn 0.5s ease-in-out;
 }
+
 @keyframes fadeIn {
-    from { opacity: 0; transform: translateY(10px); }
-    to { opacity: 1; transform: translateY(0); }
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
+
 .hidden {
     display: none;
 }
+
 .chart-container {
     position: relative;
     width: 100%;
@@ -40,19 +44,23 @@ body {
     height: 300px;
     max-height: 400px;
 }
+
 .chart-container canvas {
     width: 100%;
     height: 100%;
 }
+
 @media (min-width: 768px) {
     .chart-container {
         height: 350px;
     }
 }
+
 .flow-box {
     border: 2px solid #E0E0E0;
     background-color: #FFFFFF;
 }
+
 .flow-arrow {
     position: relative;
     width: 2px;
@@ -60,6 +68,7 @@ body {
     background-color: #BDBDBD;
     margin: 0 auto;
 }
+
 .flow-arrow::after {
     content: '';
     position: absolute;
@@ -72,7 +81,7 @@ body {
     border-right: 6px solid transparent;
     border-top: 8px solid #BDBDBD;
 }
-/* Custom slider styles */
+
 input[type="range"] {
     -webkit-appearance: none;
     appearance: none;
@@ -82,6 +91,7 @@ input[type="range"] {
     border-radius: 5px;
     outline: none;
 }
+
 input[type="range"]::-webkit-slider-thumb {
     -webkit-appearance: none;
     appearance: none;
@@ -91,6 +101,7 @@ input[type="range"]::-webkit-slider-thumb {
     cursor: pointer;
     border-radius: 50%;
 }
+
 input[type="range"]::-moz-range-thumb {
     width: 20px;
     height: 20px;
@@ -98,63 +109,37 @@ input[type="range"]::-moz-range-thumb {
     cursor: pointer;
     border-radius: 50%;
 }
-/* Custom select and textarea styles for builder */
-.builder-select, .builder-textarea {
+
+.builder-select,
+.builder-textarea {
     background-color: #fff;
     border: 1px solid #D1D5DB;
     border-radius: 0.375rem;
     padding: 0.5rem 0.75rem;
     transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
 }
-.builder-select:focus, .builder-textarea:focus {
+
+.builder-select:focus,
+.builder-textarea:focus {
     outline: none;
     border-color: #4A90E2;
     box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.5);
 }
+
 .favorite-btn {
     cursor: pointer;
-    color: #d1d5db; /* gray-300 */
+    color: #d1d5db;
     transition: color 0.2s;
 }
+
 .favorite-btn.favorited {
-    color: #facc15; /* yellow-400 */
+    color: #facc15;
 }
+
 .favorite-btn:hover {
-    color: #fde047; /* yellow-300 */
+    color: #fde047;
 }
-/* Simulator & Case Study Styles */
-.scenario-option, .category-option {
-    border: 1px solid #e5e7eb;
-    transition: all 0.2s ease-in-out;
-}
-.scenario-option:hover, .category-option:hover {
-    border-color: #4A90E2;
-    background-color: #eff6ff;
-}
-.scenario-option.selected {
-    border-color: #4A90E2;
-    box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.5);
-}
-.scenario-option.correct {
-    background-color: #dcfce7;
-    border-color: #22c55e;
-}
-.scenario-option.incorrect {
-    background-color: #fee2e2;
-    border-color: #ef4444;
-}
- .code-block {
-     background-color: #f3f4f6;
-     border: 1px solid #e5e7eb;
-     padding: 1rem;
-     border-radius: 0.5rem;
-     font-family: 'Courier New', Courier, monospace;
-     font-size: 0.875rem;
-     overflow-x: auto;
-     white-space: pre-wrap;
-     color: #374151;
-}
-/* Accordion styles for Handling Resistance */
+
 .resistance-item summary {
     cursor: pointer;
     padding: 1rem;
@@ -163,17 +148,21 @@ input[type="range"]::-moz-range-thumb {
     font-weight: 600;
     transition: background-color 0.2s;
 }
- .resistance-item summary:hover {
+
+.resistance-item summary:hover {
     background-color: #f3f4f6;
- }
+}
+
 .resistance-item[open] summary {
     background-color: #eff6ff;
     color: #4A90E2;
 }
+
 .resistance-item .answer {
     padding: 1rem;
     border-top: 1px solid #e5e7eb;
 }
+
 .spinner {
     border: 4px solid rgba(0, 0, 0, 0.1);
     width: 36px;
@@ -182,22 +171,45 @@ input[type="range"]::-moz-range-thumb {
     border-left-color: #4A90E2;
     animation: spin 1s ease infinite;
 }
+
 @keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
+    0% {
+        transform: rotate(0deg);
+    }
+
+    100% {
+        transform: rotate(360deg);
+    }
 }
-/* Animated Subtitle */
+
 .subtitle-animate-in {
     animation: fadeInSmooth 0.5s ease-out forwards;
 }
+
 .subtitle-animate-out {
     animation: fadeOutSmooth 0.5s ease-in forwards;
 }
+
 @keyframes fadeInSmooth {
-    from { opacity: 0; transform: translateY(10px); }
-    to { opacity: 1; transform: translateY(0); }
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
+
 @keyframes fadeOutSmooth {
-    from { opacity: 1; transform: translateY(0); }
-    to { opacity: 0; transform: translateY(-10px); }
+    from {
+        opacity: 1;
+        transform: translateY(0);
+    }
+
+    to {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
 }

--- a/gbs-prompts/index.html
+++ b/gbs-prompts/index.html
@@ -155,7 +155,7 @@
 
     <!-- =========== Gem Configuration Modal =========== -->
 <div id="gem-modal" class="hidden fixed inset-0 bg-gray-900 bg-opacity-50 modal-backdrop overflow-y-auto h-full w-full z-50">
-    <div class="relative top-10 mx-auto p-6 border shadow-2xl rounded-xl bg-white modal-content" style="max-width: 700px;">
+    <div class="relative top-10 mx-auto p-6 border shadow-2xl rounded-xl bg-white modal-content">
         <div class="text-center border-b pb-4 mb-6">
             <div class="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-r from-green-500 to-emerald-500 rounded-full mb-4">
                 <span class="text-white text-2xl">💎</span>

--- a/shared/styles/pages/gbs-prompts.css
+++ b/shared/styles/pages/gbs-prompts.css
@@ -91,6 +91,10 @@ body {
     color: #4A90E2;
 }
 
+.modal-content {
+    max-width: 700px;
+}
+
 .hidden {
     display: none;
 }

--- a/shared/styles/pages/get-entry-ids.css
+++ b/shared/styles/pages/get-entry-ids.css
@@ -1,5 +1,6 @@
 body { font-family: Arial, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; }
 .container { background: #f5f5f5; padding: 20px; border-radius: 8px; margin: 20px 0; }
+.hidden { display: none; }
 input[type="url"] { width: 100%; padding: 10px; margin: 10px 0; border: 1px solid #ddd; border-radius: 4px; }
 button { background: #4285f4; color: white; padding: 10px 20px; border: none; border-radius: 4px; cursor: pointer; }
 button:hover { background: #3367d6; }


### PR DESCRIPTION
## Summary
- split the Gemini workshop stylesheet into a shared main file and component-specific definitions and update the page to load them both
- move modal sizing into the prompts stylesheet and replace inline display toggles with utility classes across feedback tools
- rely on reusable color classes in the AI SME template instead of inline values

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c97982ae4483309217f197b5c787a1