### PR TITLE
Add error boundary handling for async flows

### DIFF
--- a/gbs-ai-workshop/app.js
+++ b/gbs-ai-workshop/app.js
@@ -1,3 +1,4 @@
+import { ErrorBoundary } from './src/components/common/ErrorBoundary.js';
 import { initFirebase } from './src/services/firebaseService.js';
 import { initNavigation } from './src/sections/Navigation.js';
 import { initWhySection } from './src/sections/WhySection.js';
@@ -11,19 +12,26 @@ import { initMyDaySection } from './src/sections/MyDaySection.js';
 import { initCaseStudiesSection } from './src/sections/CaseStudiesSection.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
-    const showFirebaseError = (message) => {
-        const container = document.getElementById('firebase-error');
-        if (!container) return;
-        container.textContent = message;
-        container.classList.remove('hidden');
-    };
-
-    const clearFirebaseError = () => {
-        const container = document.getElementById('firebase-error');
-        if (!container) return;
-        container.textContent = '';
-        container.classList.add('hidden');
-    };
+    const firebaseErrorBoundary = new ErrorBoundary({
+        id: 'firebase-ui',
+        fallbackMessage: 'We couldn\'t connect to your workspace. Please try again later.',
+        renderer: ({ message }) => {
+            const container = document.getElementById('firebase-error');
+            if (container) {
+                container.textContent = message;
+                container.classList.remove('hidden');
+            } else if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+                window.alert(message);
+            }
+        },
+        clearRenderer: () => {
+            const container = document.getElementById('firebase-error');
+            if (container) {
+                container.textContent = '';
+                container.classList.add('hidden');
+            }
+        }
+    });
 
     const navigation = initNavigation({
         sectionInitializers: {
@@ -39,7 +47,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     });
 
-    await initFirebase({ onError: showFirebaseError, onClear: clearFirebaseError });
+    await initFirebase({ boundary: firebaseErrorBoundary });
 
     navigation?.refresh();
 });

--- a/gbs-ai-workshop/main.js
+++ b/gbs-ai-workshop/main.js
@@ -2,23 +2,28 @@ import { $, $$ } from '../shared/scripts/utils/dom-helpers.js';
 import { initializeDropdown } from '../shared/scripts/components/dropdown.js';
 import { initializeNavigation } from '../shared/scripts/components/navigation.js';
 import { BackToTop } from '../shared/scripts/gbs-core.js';
+import { ErrorBoundary } from './src/components/common/ErrorBoundary.js';
+
+const coreErrorBoundary = new ErrorBoundary({
+  id: 'gbs-ai-core',
+  fallbackMessage: 'We hit a snag while initializing the page. Please refresh to try again.'
+});
 
 /**
  * Initializes all dropdown components on the page by finding
  * elements with the `data-dropdown` attribute.
  */
 function initComponents() {
-  try {
-    // Initialize all dropdowns
+  coreErrorBoundary.guard(() => {
     const dropdownElements = $$('[data-dropdown]');
     dropdownElements.forEach(initializeDropdown);
 
-    // Initialize mobile navigation
     initializeNavigation();
-
-  } catch (error) {
-    console.error("Error initializing core components:", error);
-  }
+  }, {
+    message: 'We couldn\'t initialize the navigation controls. Some menus may not work until you refresh.',
+    rethrow: false,
+    context: { scope: 'core.initComponents' }
+  });
 }
 
 /**
@@ -52,15 +57,17 @@ function initBackToTopButton() {
  * This function is the entry point for all JavaScript on the page.
  */
 function main() {
-  try {
+  coreErrorBoundary.guard(() => {
     initComponents();
     new BackToTop();
     // NOTE: Other page-specific logic (like charts, simulators, etc.)
     // will be progressively moved from the inline script to this file or other modules.
     console.log("GBS AI Workshop page scripts initialized successfully.");
-  } catch (error) {
-    console.error("Failed to initialize GBS AI Workshop page:", error);
-  }
+  }, {
+    message: 'We couldn\'t initialize the workshop page. Please refresh and try again.',
+    rethrow: false,
+    context: { scope: 'core.main' }
+  });
 }
 
 // Run the main function when the DOM is fully loaded.

--- a/gbs-ai-workshop/src/components/common/ErrorBoundary.js
+++ b/gbs-ai-workshop/src/components/common/ErrorBoundary.js
@@ -1,0 +1,187 @@
+const HANDLED_SYMBOL = Symbol.for('gbslearninghub:error-boundary:handled');
+let boundaryCounter = 0;
+
+function defaultReporter(error, context = {}) {
+    if (typeof console !== 'undefined' && typeof console.error === 'function') {
+        const scope = context.scope ? ` [${context.scope}]` : '';
+        console.error(`Error captured${scope}:`, error);
+    }
+}
+
+function defaultRenderer({ message }) {
+    if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+        window.alert(message);
+    }
+}
+
+function getHandledMap(error, createIfMissing = false) {
+    if (!error || (typeof error !== 'object' && typeof error !== 'function')) {
+        return null;
+    }
+
+    let handledMap = error[HANDLED_SYMBOL];
+    if (!handledMap && createIfMissing) {
+        handledMap = new Map();
+        try {
+            Object.defineProperty(error, HANDLED_SYMBOL, {
+                configurable: true,
+                enumerable: false,
+                writable: false,
+                value: handledMap
+            });
+        } catch (defineError) {
+            // If defining the property fails (e.g., frozen object), fall back to assignment.
+            error[HANDLED_SYMBOL] = handledMap;
+        }
+    }
+
+    return handledMap || null;
+}
+
+function resolveBoundaryId(id, name) {
+    if (id) return id;
+    if (name) return name;
+    boundaryCounter += 1;
+    return `error-boundary-${boundaryCounter}`;
+}
+
+export class ErrorBoundary {
+    constructor({
+        id,
+        name,
+        fallbackMessage = 'Something went wrong. Please try again.',
+        reporter = defaultReporter,
+        renderer = defaultRenderer,
+        clearRenderer = null
+    } = {}) {
+        this.id = resolveBoundaryId(id, name);
+        this.fallbackMessage = fallbackMessage;
+        this.reporter = typeof reporter === 'function' ? reporter : defaultReporter;
+        this.renderer = typeof renderer === 'function' ? renderer : defaultRenderer;
+        this.clearRenderer = typeof clearRenderer === 'function' ? clearRenderer : null;
+        this.lastError = null;
+    }
+
+    static isHandledBy(error, boundaryId) {
+        const handledMap = getHandledMap(error, false);
+        if (!handledMap) return false;
+        return handledMap.has(boundaryId);
+    }
+
+    hasHandled(error) {
+        return ErrorBoundary.isHandledBy(error, this.id);
+    }
+
+    annotateError(error, payload) {
+        if (!error || (typeof error !== 'object' && typeof error !== 'function')) {
+            return;
+        }
+
+        const handledMap = getHandledMap(error, true);
+        handledMap.set(this.id, payload);
+
+        if (typeof error.friendlyMessage === 'undefined' && payload?.message) {
+            error.friendlyMessage = payload.message;
+        }
+    }
+
+    capture(error, { message, context = {}, forceRender = false } = {}) {
+        const friendlyMessage = message || this.fallbackMessage;
+        const alreadyHandled = this.hasHandled(error);
+        const payload = {
+            message: friendlyMessage,
+            context: { ...context, boundary: this.id }
+        };
+
+        this.lastError = { error, ...payload };
+        this.annotateError(error, payload);
+
+        try {
+            this.reporter?.(error, { ...payload.context, message: friendlyMessage });
+        } catch (reportError) {
+            // Reporter failures should never break application flow.
+        }
+
+        if (!alreadyHandled || forceRender) {
+            this.render(payload);
+        }
+
+        return friendlyMessage;
+    }
+
+    render(payload) {
+        const renderer = this.renderer || defaultRenderer;
+        if (typeof renderer === 'function') {
+            try {
+                renderer({ ...payload, boundary: this });
+                return;
+            } catch (renderError) {
+                defaultReporter(renderError, { scope: `${this.id}:renderer` });
+            }
+        }
+
+        if (renderer !== defaultRenderer && typeof defaultRenderer === 'function') {
+            defaultRenderer({ ...payload, boundary: this });
+        }
+    }
+
+    clear() {
+        this.lastError = null;
+        if (typeof this.clearRenderer === 'function') {
+            try {
+                this.clearRenderer({ boundary: this });
+            } catch (clearError) {
+                defaultReporter(clearError, { scope: `${this.id}:clearRenderer` });
+            }
+        }
+    }
+
+    guard(operation, { message, context, rethrow = true, fallbackValue, clearOnSuccess = true } = {}) {
+        try {
+            const result = operation();
+            if (clearOnSuccess) {
+                this.clear();
+            }
+            return result;
+        } catch (error) {
+            this.capture(error, { message, context });
+            if (rethrow) {
+                throw error;
+            }
+            return fallbackValue;
+        }
+    }
+
+    async guardAsync(operation, { message, context, rethrow = true, fallbackValue, clearOnSuccess = true } = {}) {
+        try {
+            const result = await operation();
+            if (clearOnSuccess) {
+                this.clear();
+            }
+            return result;
+        } catch (error) {
+            this.capture(error, { message, context });
+            if (rethrow) {
+                throw error;
+            }
+            return fallbackValue;
+        }
+    }
+
+    wrap(operation, options = {}) {
+        return (...args) => this.guard(() => operation(...args), { ...options, context: { ...(options.context || {}), args } });
+    }
+
+    wrapAsync(operation, options = {}) {
+        return async (...args) => this.guardAsync(() => operation(...args), { ...options, context: { ...(options.context || {}), args } });
+    }
+
+    getLastError() {
+        return this.lastError;
+    }
+}
+
+export function hasBeenHandled(error) {
+    const handledMap = getHandledMap(error, false);
+    return handledMap ? handledMap.size > 0 : false;
+}

--- a/gbs-ai-workshop/src/data/loaders.js
+++ b/gbs-ai-workshop/src/data/loaders.js
@@ -1,9 +1,31 @@
+import { ErrorBoundary } from '../components/common/ErrorBoundary.js';
+
 const dataCache = new Map();
+
+const FRIENDLY_MESSAGES = {
+    prompts: "We couldn't load the prompt library right now. Please try again later.",
+    scenarios: "We couldn't load the simulator scenarios right now. Please try again later.",
+    myDayEvents: "We couldn't load the My Day experience right now. Please try again later.",
+    caseStudies: "We couldn't load the case studies right now. Please refresh the page.",
+    opportunityData: "We couldn't load the opportunity framework right now. Please refresh the page.",
+    whySubtitles: "We couldn't load new inspiration right now. Please try again later."
+};
+
+const dataBoundary = new ErrorBoundary({
+    id: 'data-loaders',
+    fallbackMessage: "We couldn't load the workshop content. Please refresh and try again.",
+    renderer: () => {}
+});
 
 function loadData(key, importer) {
     if (!dataCache.has(key)) {
         const promise = importer().catch((error) => {
             dataCache.delete(key);
+            const message = FRIENDLY_MESSAGES[key] || dataBoundary.fallbackMessage;
+            dataBoundary.capture(error, {
+                message,
+                context: { scope: `data.${key}` }
+            });
             throw error;
         });
         dataCache.set(key, promise);

--- a/gbs-ai-workshop/src/sections/CaseStudiesSection.js
+++ b/gbs-ai-workshop/src/sections/CaseStudiesSection.js
@@ -1,13 +1,29 @@
+import { ErrorBoundary } from '../components/common/ErrorBoundary.js';
 import { loadCaseStudies } from '../data/loaders.js';
 
 let initialized = false;
 let isLoading = false;
 let caseStudiesData = {};
+let containerElement = null;
+
+const caseStudiesBoundary = new ErrorBoundary({
+    id: 'case-studies-section',
+    fallbackMessage: "We couldn't load case studies right now. Please try again later.",
+    renderer: ({ message }) => {
+        if (containerElement) {
+            containerElement.innerHTML = `<div class="text-center text-red-500 py-8">${message}</div>`;
+        } else if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+            window.alert(message);
+        }
+    }
+});
 
 export async function initCaseStudiesSection() {
     if (initialized || isLoading) return;
     const container = document.getElementById('case-study-container');
     if (!container) return;
+
+    containerElement = container;
 
     isLoading = true;
     container.innerHTML = `<div class="text-center text-gray-500 py-8 animate-pulse">Loading case studies...</div>`;
@@ -52,8 +68,10 @@ export async function initCaseStudiesSection() {
 
         initialized = true;
     } catch (error) {
-        console.error('Failed to load case studies data', error);
-        container.innerHTML = `<div class="text-center text-red-500 py-8">We couldn't load case studies right now. Please try again later.</div>`;
+        caseStudiesBoundary.capture(error, {
+            message: "We couldn't load case studies right now. Please try again later.",
+            context: { scope: 'case-studies.load' }
+        });
     } finally {
         isLoading = false;
     }

--- a/gbs-ai-workshop/src/sections/MyDaySection.js
+++ b/gbs-ai-workshop/src/sections/MyDaySection.js
@@ -1,3 +1,4 @@
+import { ErrorBoundary } from '../components/common/ErrorBoundary.js';
 import { loadMyDayEvents } from '../data/loaders.js';
 
 let myDayContainer;
@@ -6,6 +7,18 @@ let myDayEventsData = [];
 let eventsLoaded = false;
 let eventsLoading = false;
 let hasSetup = false;
+
+const myDayBoundary = new ErrorBoundary({
+    id: 'my-day-section',
+    fallbackMessage: "We couldn't load the day simulator right now. Please try again later.",
+    renderer: ({ message }) => {
+        if (myDayContainer) {
+            myDayContainer.innerHTML = `<div class="text-center text-red-500 py-8">${message}</div>`;
+        } else if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+            window.alert(message);
+        }
+    }
+});
 
 export async function initMyDaySection() {
     myDayContainer = document.getElementById('my-day-container');
@@ -39,8 +52,10 @@ export async function initMyDaySection() {
 
         loadDayEvent(0);
     } catch (error) {
-        console.error('Failed to load My Day scenarios', error);
-        myDayContainer.innerHTML = `<div class="text-center text-red-500 py-8">We couldn't load the day simulator right now. Please try again later.</div>`;
+        myDayBoundary.capture(error, {
+            message: "We couldn't load the day simulator right now. Please try again later.",
+            context: { scope: 'my-day.load' }
+        });
     } finally {
         eventsLoading = false;
     }

--- a/gbs-ai-workshop/src/sections/WhySection.js
+++ b/gbs-ai-workshop/src/sections/WhySection.js
@@ -1,15 +1,40 @@
+import { ErrorBoundary } from '../components/common/ErrorBoundary.js';
 import { loadWhySubtitles } from '../data/loaders.js';
 
 let subtitleIntervalId;
 let isLoading = false;
+let subtitleElementRef = null;
+
+const whySectionBoundary = new ErrorBoundary({
+    id: 'why-section',
+    fallbackMessage: 'Unable to load examples right now.',
+    renderer: ({ message }) => {
+        if (subtitleElementRef) {
+            subtitleElementRef.textContent = message;
+            subtitleElementRef.classList.remove('subtitle-animate-in', 'subtitle-animate-out', 'animate-pulse');
+            subtitleElementRef.classList.remove('text-gray-400');
+            subtitleElementRef.classList.add('text-gray-500');
+        } else if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+            window.alert(message);
+        }
+    },
+    clearRenderer: () => {
+        if (subtitleElementRef) {
+            subtitleElementRef.classList.remove('text-gray-500');
+        }
+    }
+});
 
 export async function initWhySection() {
     const subtitleElement = document.getElementById('animated-subtitle');
     if (!subtitleElement || subtitleIntervalId || isLoading) return;
 
+    subtitleElementRef = subtitleElement;
+
     isLoading = true;
     subtitleElement.textContent = 'Loading inspiration...';
     subtitleElement.classList.add('text-gray-400', 'animate-pulse');
+    whySectionBoundary.clear();
 
     try {
         const subtitles = await loadWhySubtitles();
@@ -39,11 +64,10 @@ export async function initWhySection() {
 
         subtitleIntervalId = window.setInterval(cycleSubtitles, 4000);
     } catch (error) {
-        console.error('Failed to load Why section subtitles', error);
-        subtitleElement.textContent = 'Unable to load examples right now.';
-        subtitleElement.classList.remove('subtitle-animate-in', 'subtitle-animate-out');
-        subtitleElement.classList.remove('animate-pulse', 'text-gray-400');
-        subtitleElement.classList.add('text-gray-500');
+        whySectionBoundary.capture(error, {
+            message: 'Unable to load examples right now.',
+            context: { scope: 'why-section.load' }
+        });
     } finally {
         isLoading = false;
     }


### PR DESCRIPTION
## Summary
- add a reusable ErrorBoundary helper that logs, tracks, and renders friendly error messages
- wrap Firebase initialization, AI service calls, and dynamic data imports in the new boundary
- replace console.error usage across workshop components and sections with boundary-driven user messaging

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68c98989302883309fa0c5af6aa5df1d